### PR TITLE
Simplify packet dissector to eliminate incoming buffer

### DIFF
--- a/src/utility/dissector.h
+++ b/src/utility/dissector.h
@@ -141,7 +141,7 @@ public:
 			reset();
 		}
 
-		if (packetSize < PACKET_MAX_SIZE) {
+		if (packetSize <= PACKET_MAX_SIZE) {
 			// Add to the end of the protocolBuffer
 			memcpy(_protocolBuffer + _protocolBufferIndex, packetBuffer, packetSize);
 			_protocolBufferIndex += packetSize;


### PR DESCRIPTION
Eliminating incoming buffer will limit damaging effects of confusing or corrupted packets, free up a couple hundred bytes of global memory, speed up incoming packet processing, and get rid of a place bugs were hiding.