### PR TITLE
Modify AppleMIDI.run() to process one packet from each port

### DIFF
--- a/src/AppleMidi.hpp
+++ b/src/AppleMidi.hpp
@@ -128,44 +128,18 @@ inline void AppleMidi_Class<UdpClass>::run()
 {
 	byte _packetBuffer[PACKET_MAX_SIZE];
 
-	// Get first packet of CONTROL logic, if any
+	// Process one control packet, if available
 	int packetSize = _controlUDP.parsePacket();
-	int bytesRead = 0;
-
-	// While we still have packets to process
-	while (packetSize > 0) {
-		// While we still have bytes to process in the packet
-		while (packetSize > 0) {
-			bytesRead = _controlUDP.read(_packetBuffer, PACKET_MAX_SIZE);
-			packetSize = packetSize - bytesRead;
-			_controlDissector.addPacket(_packetBuffer, bytesRead);
-		}
-
-		// Dissect packet only after all bytes have been added to the buffer
-		_controlDissector.dissect();
-
-		// Get next packet
-		packetSize = _controlUDP.parsePacket();
+	if (packetSize) {
+		packetSize = _controlUDP.read(_packetBuffer, sizeof(_packetBuffer));
+		_controlDissector.addPacket(_packetBuffer, packetSize);
 	}
 
-	// Get first packet of CONTENT logic, if any
+	// Process one control packet, if available
 	packetSize = _contentUDP.parsePacket();
-	bytesRead = 0;
-
-	// While we still have packets to process
-	while (packetSize > 0) {
-		// While we still have bytes to process in the packet
-		while (packetSize > 0) {
-			bytesRead = _contentUDP.read(_packetBuffer, PACKET_MAX_SIZE);
-			packetSize = packetSize - bytesRead;
-			_contentDissector.addPacket(_packetBuffer, bytesRead);
-		}
-
-		// Dissect packet only after all bytes have been added to the buffer
-		_contentDissector.dissect();
-
-		// Get next packet
-		packetSize = _contentUDP.parsePacket();
+	if (packetSize) {
+		packetSize = _contentUDP.read(_packetBuffer, sizeof(_packetBuffer));
+		_contentDissector.addPacket(_packetBuffer, packetSize);
 	}
 
 	// resend invitations

--- a/src/utility/dissector.h
+++ b/src/utility/dissector.h
@@ -141,7 +141,7 @@ public:
 			reset();
 		}
 
-		if (packetSize < PACKET_MAX_SIZE) {
+		if (packetSize <= PACKET_MAX_SIZE) {
 			// Add to the end of the protocolBuffer
 			memcpy(_protocolBuffer + _protocolBufferIndex, packetBuffer, packetSize);
 			_protocolBufferIndex += packetSize;

--- a/src/utility/dissector.h
+++ b/src/utility/dissector.h
@@ -84,10 +84,6 @@ public:
 		Serial.println("No dissectors handled last message");
 		#endif
 	}
-
-	void dissect() {
-		// nah screw that
-	}
 };
 
 

--- a/src/utility/dissector.h
+++ b/src/utility/dissector.h
@@ -3,7 +3,7 @@
  *  Project		Arduino AppleMIDI Library
  *	@brief		AppleMIDI Library for the Arduino
  *	Version		0.3
- *  @author		lathoub, hackmancoltaire
+ *  @author		lathoub, hackmancoltaire, bluebie
  *	@date		04/04/14
  *  License		Code is open source so please feel free to do anything you want with it; you buy me a beer if you use this and we meet someday (Beerware license).
  */


### PR DESCRIPTION
AppleMIDI.run() in it's current form processes packets until the queue is emptied. Under high network load on devices with a watchdog timer enabled, this can cause the device to stall and reset. Even on devices without this issue, looping until the queue is empty can be undesirable. A musical device should react to new information quickly, and stalling like this can negatively affect the smoothness of robotic and light animations.

This change should be considered carefully, because some existing projects maybe depending on the earlier behaviour, but I think it's a change worth making. It's completely eliminated the resets I was seeing on my ESP8266 devices when they were flooded with messages as apps changed to drastically different states and had a lot of updates to make in one go.