### PR TITLE
Fix permission issue when APPLEMIDI_USE_EVENTS is defined

### DIFF
--- a/src/AppleMidi.h
+++ b/src/AppleMidi.h
@@ -222,6 +222,7 @@ private:
 
 #endif // APPLEMIDI_BUILD_OUTPUT
 
+public:
 	inline int	GetFreeSessionSlot();
 	inline int	GetSessionSlotUsingSSrc(const uint32_t ssrc);
 	inline int	GetSessionSlotUsingInitiatorToken(const uint32_t initiatorToken);


### PR DESCRIPTION
Some useful methods on AppleMIDI were becoming mistakenly private when
APPLEMIDI_USE_EVENTS was defined.