### PR TITLE
Fix AppleMIDI not working with Mac OSX

### DIFF
--- a/src/AppleMidi.h
+++ b/src/AppleMidi.h
@@ -26,7 +26,7 @@
 #include "utility/RtpMidi_Clock.h"
 
 #include "utility/dissector.h"
-#include "utility/PacketWriter.h"
+#include "utility/PacketWriter.hpp"
 
 #if defined(ARDUINO)
 #if defined(ESP8266)

--- a/src/AppleMidi.h
+++ b/src/AppleMidi.h
@@ -26,6 +26,7 @@
 #include "utility/RtpMidi_Clock.h"
 
 #include "utility/dissector.h"
+#include "utility/PacketWriter.h"
 
 #if defined(ARDUINO)
 #if defined(ESP8266)

--- a/src/AppleMidi.hpp
+++ b/src/AppleMidi.hpp
@@ -3,7 +3,7 @@
  *  Project		Arduino AppleMIDI Library
  *	@brief		AppleMIDI Library for the Arduino
  *	Version		0.4
- *  @author		lathoub, hackmancoltaire
+ *  @author		lathoub, hackmancoltaire, chris-zen
  *	@date		13/04/14
  *  License		Code is open source so please feel free to do anything you want with it; you buy me a beer if you use this and we meet someday (Beerware license).
  */
@@ -1442,15 +1442,18 @@ inline void AppleMidi_Class<UdpClass>::write(UdpClass& udp, AppleMIDI_Syncroniza
 	int success = udp.beginPacket(ip, port);
 	Debug::Assert(success, "udp.beginPacket failed");
 
-		// Set the correct endian
-		sy.ssrc = AppleMIDI_Util::toEndian(sy.ssrc);
-		sy.count = AppleMIDI_Util::toEndian(sy.count);
-		sy.timestamps[0] = AppleMIDI_Util::toEndian(sy.timestamps[0]);
-		sy.timestamps[1] = AppleMIDI_Util::toEndian(sy.timestamps[1]);
-		sy.timestamps[2] = AppleMIDI_Util::toEndian(sy.timestamps[2]);
-
-		size_t bytesWritten = udp.write(reinterpret_cast<uint8_t*>(&sy), sizeof(sy));
-		Debug::Assert(bytesWritten == sizeof(sy), "error writing sy");
+	PacketWriter<UdpClass> writer(udp);
+	writer.write(sy.signature[0]);
+	writer.write(sy.signature[1]);
+	writer.write(sy.command[0]);
+	writer.write(sy.command[1]);
+	writer.write(sy.ssrc);
+	writer.write(sy.count);
+	writer.writePadding(3);
+	writer.write(sy.timestamps[0]);
+	writer.write(sy.timestamps[1]);
+	writer.write(sy.timestamps[2]);
+	Debug::Assert(writer.allWritten(), "error writing sy");
 
 	success = udp.endPacket();
 	Debug::Assert(success, "udp.endPacket failed");

--- a/src/AppleMidi.hpp
+++ b/src/AppleMidi.hpp
@@ -83,6 +83,7 @@ inline bool AppleMidi_Class<UdpClass>::begin(const char* sessionName, uint16_t p
 		Serial.println(" chars. Name will be clipped.");
 	}
 #endif
+
 	strncpy(_sessionName, sessionName, SESSION_NAME_MAX_LEN);
 
 	Port = port;
@@ -153,7 +154,7 @@ inline uint32_t AppleMidi_Class<UdpClass>::getSynchronizationSource()
 	if (0 == _ssrc) // _ssrc initialized to 0 in constructor
 	{
 		// A call randonSeed is mandatory, with millis as a seed.
-		// The time between booting and needing the SSRC for the first time (first  network traffic) is 
+		// The time between booting and needing the SSRC for the first time (first  network traffic) is
 		// a good enough random seed.
 		long seed = (long)micros();
 		randomSeed(seed);
@@ -469,7 +470,7 @@ void AppleMidi_Class<UdpClass>::OnSyncronization(void* sender, AppleMIDI_Syncron
 	Serial.println("");
 #endif
 
-	// If we know this session already, ignore it.
+	// If we don't know this session, ignore it.
 
 	int index = GetSessionSlotUsingSSrc(synchronization.ssrc);
 	if (index < 0)
@@ -480,37 +481,38 @@ void AppleMidi_Class<UdpClass>::OnSyncronization(void* sender, AppleMIDI_Syncron
 		return;
 	}
 
-	if (synchronization.count == 0) /* From session initiator */
-	{
-		synchronization.count = 1;
-		synchronization.timestamps[synchronization.count] = _rtpMidiClock.Now();
-	}
-	else if (synchronization.count == 1) /* From session responder */
-	{
-		/* compute media delay */
-		//uint64_t diff = (now - synchronization.timestamps[0]) / 2;
-		/* approximate time difference between peer and self */
-		//diff = synchronization.timestamps[2] + diff - now;
+	switch (synchronization.count) {
+		case SYNC_CK0: /* From session initiator */
+			synchronization.count = SYNC_CK1;
+			synchronization.timestamps[synchronization.count] = _rtpMidiClock.Now();
+			break;
 
-		// Send CK2
-		synchronization.count = 2;
-		synchronization.timestamps[synchronization.count] = _rtpMidiClock.Now();
+		case SYNC_CK1: /* From session responder */
+			/* compute media delay */
+			//uint64_t diff = (now - synchronization.timestamps[0]) / 2;
+			/* approximate time difference between peer and self */
+			//diff = synchronization.timestamps[2] + diff - now;
 
-		/* getting this message means that the responder is still alive! */
-		/* remember the time, if it takes to long to respond, we can assume the responder is dead */
-		/* not implemented at this stage*/
-		//Sessions[index].syncronization.lastTime = _rtpMidiClock.Now();
-		//Sessions[index].syncronization.count++;
-	}
-	else if (synchronization.count == 2) /* From session initiator */
-	{
-		/* compute media delay */
-		//uint64_t diff = (synchronization.timestamps[2] - synchronization.timestamps[0]) / 2;
-		/* approximate time difference between peer and self */
-		//diff = synchronization.timestamps[2] + diff - now;
+			// Send CK2
+			synchronization.count = SYNC_CK2;
+			synchronization.timestamps[synchronization.count] = _rtpMidiClock.Now();
 
-		synchronization.count = 0;
-		synchronization.timestamps[synchronization.count] = _rtpMidiClock.Now();
+			/* getting this message means that the responder is still alive! */
+			/* remember the time, if it takes to long to respond, we can assume the responder is dead */
+			/* not implemented at this stage*/
+			//Sessions[index].syncronization.lastTime = _rtpMidiClock.Now();
+			//Sessions[index].syncronization.count++;
+			break;
+
+		case SYNC_CK2: /* From session initiator */
+			/* compute media delay */
+			//uint64_t diff = (synchronization.timestamps[2] - synchronization.timestamps[0]) / 2;
+			/* approximate time difference between peer and self */
+			//diff = synchronization.timestamps[2] + diff - now;
+
+			synchronization.count = SYNC_CK0;
+			synchronization.timestamps[synchronization.count] = _rtpMidiClock.Now();
+			break;
 	}
 
 	AppleMIDI_Syncronization synchronizationResponse(getSynchronizationSource(), synchronization.count, synchronization.timestamps);
@@ -1599,7 +1601,7 @@ inline void AppleMidi_Class<UdpClass>::internalSend(Session_t& session, MidiType
 
 		_rtpMidi.ssrc = getSynchronizationSource();
 		_rtpMidi.sequenceNr++;
-		// _rtpMidi.timestamp = _rtpMidiClock.Now();
+		_rtpMidi.timestamp = _rtpMidiClock.Now();
 		_rtpMidi.beginWrite(_contentUDP, session.contentIP, session.contentPort);
 
 		// Length
@@ -1642,7 +1644,7 @@ inline void AppleMidi_Class<UdpClass>::internalSend(Session_t& session, MidiType
 {
 	_rtpMidi.ssrc = getSynchronizationSource();
 	_rtpMidi.sequenceNr++;
-	// _rtpMidi.timestamp = _rtpMidiClock.Now();
+	_rtpMidi.timestamp = _rtpMidiClock.Now();
 	_rtpMidi.beginWrite(_contentUDP, session.contentIP, session.contentPort);
 
 	uint8_t length = 1;
@@ -1681,7 +1683,7 @@ inline void AppleMidi_Class<UdpClass>::internalSend(Session_t& session, MidiType
 {
 	_rtpMidi.ssrc = getSynchronizationSource();
 	_rtpMidi.sequenceNr++;
-	// _rtpMidi.timestamp = _rtpMidiClock.Now();
+	_rtpMidi.timestamp = _rtpMidiClock.Now();
 	_rtpMidi.beginWrite(_contentUDP, session.contentIP, session.contentPort);
 
 	uint8_t length = 2;
@@ -1715,7 +1717,7 @@ inline void AppleMidi_Class<UdpClass>::internalSend(Session_t& session, MidiType
 {
 	_rtpMidi.ssrc = getSynchronizationSource();
 	_rtpMidi.sequenceNr++;
-	// _rtpMidi.timestamp = _rtpMidiClock.Now();
+	_rtpMidi.timestamp = _rtpMidiClock.Now();
 	_rtpMidi.beginWrite(_contentUDP, session.contentIP, session.contentPort);
 
 	uint8_t length = 3;

--- a/src/utility/AppleMidi_Defs.h
+++ b/src/utility/AppleMidi_Defs.h
@@ -31,6 +31,7 @@
 #define SYNC_CK1 1
 #define SYNC_CK2 2
 
+
 BEGIN_APPLEMIDI_NAMESPACE
 
 // -----------------------------------------------------------------------------

--- a/src/utility/AppleMidi_Defs.h
+++ b/src/utility/AppleMidi_Defs.h
@@ -27,6 +27,10 @@
 
 #define SESSION_NAME_MAX_LEN 16
 
+#define SYNC_CK0 0
+#define SYNC_CK1 1
+#define SYNC_CK2 2
+
 BEGIN_APPLEMIDI_NAMESPACE
 
 // -----------------------------------------------------------------------------

--- a/src/utility/AppleMidi_Syncronization.h
+++ b/src/utility/AppleMidi_Syncronization.h
@@ -3,7 +3,7 @@
  *  Project		Arduino AppleMIDI Library
  *	@brief		AppleMIDI Library for the Arduino
  *	Version		0.3
- *  @author		lathoub
+ *  @author		lathoub, chris-zen
  *	@date		04/04/14
  *  License		Code is open source so please feel free to do anything you want with it; you buy me a beer if you use this and we meet someday (Beerware license).
  */
@@ -20,21 +20,20 @@ extern "C" {
 
 BEGIN_APPLEMIDI_NAMESPACE
 
-typedef struct __attribute__((packed)) AppleMIDI_Syncronization
+typedef struct AppleMIDI_Syncronization
 {
 	uint8_t		signature[2];
 	uint8_t		command[2];
 	uint32_t	ssrc;
 	uint8_t		count;
-	uint8_t		padding[3];
-	int64_t		timestamps[3];
+	uint64_t	timestamps[3];
 
 	AppleMIDI_Syncronization()
 	{
 		init();
 	}
 
-	AppleMIDI_Syncronization(uint32_t ssrc, uint8_t count, int64_t* ts)
+	AppleMIDI_Syncronization(uint32_t ssrc, uint8_t count, uint64_t* ts)
 	{
 		init();
 
@@ -50,7 +49,6 @@ private:
 	{
 		memcpy(signature, amSignature, sizeof(amSignature));
 		memcpy(command, amSyncronization, sizeof(amSyncronization));
-		memset(padding, 0, sizeof(padding));
 	}
 } AppleMIDI_Syncronization_t;
 

--- a/src/utility/AppleMidi_Syncronization.h
+++ b/src/utility/AppleMidi_Syncronization.h
@@ -3,7 +3,7 @@
  *  Project		Arduino AppleMIDI Library
  *	@brief		AppleMIDI Library for the Arduino
  *	Version		0.3
- *  @author		lathoub 
+ *  @author		lathoub
  *	@date		04/04/14
  *  License		Code is open source so please feel free to do anything you want with it; you buy me a beer if you use this and we meet someday (Beerware license).
  */
@@ -19,8 +19,8 @@ extern "C" {
 #endif
 
 BEGIN_APPLEMIDI_NAMESPACE
-	
-typedef struct AppleMIDI_Syncronization 
+
+typedef struct __attribute__((packed)) AppleMIDI_Syncronization
 {
 	uint8_t		signature[2];
 	uint8_t		command[2];
@@ -50,6 +50,7 @@ private:
 	{
 		memcpy(signature, amSignature, sizeof(amSignature));
 		memcpy(command, amSyncronization, sizeof(amSyncronization));
+		memset(padding, 0, sizeof(padding));
 	}
 } AppleMIDI_Syncronization_t;
 

--- a/src/utility/PacketWriter.h
+++ b/src/utility/PacketWriter.h
@@ -1,0 +1,79 @@
+/*!
+ *  @author		chris-zen
+ *	@date		19/12/16
+ *  License		Code is open source so please feel free to do anything you want with it; you buy me a beer if you use this and we meet someday (Beerware license).
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+BEGIN_APPLEMIDI_NAMESPACE
+
+template<class UdpClass>
+class PacketWriter {
+private:
+  UdpClass& udp;
+  size_t totalWritten;
+  size_t expected;
+
+public:
+  PacketWriter(UdpClass& udp) : udp(udp){
+    totalWritten = expected = 0;
+  }
+
+  bool allWritten() {
+    return totalWritten == expected;
+  }
+
+  size_t writePadding(size_t size) {
+    size_t written = 0;
+    for (int i = 0; i < size; i++) {
+      written += this->udp.write((uint8_t)0);
+    }
+    totalWritten += written;
+    expected += size;
+    return written;
+  }
+
+  size_t write(uint8_t data) {
+    size_t written = this->udp.write(data);
+    totalWritten += written;
+    expected += 1;
+    return written;
+  }
+
+  size_t write(uint16_t data) {
+    size_t written = this->udp.write((data >> 8) & 0xff) +
+                      this->udp.write(data & 0xff);
+    totalWritten += written;
+    expected += 2;
+    return written;
+  }
+
+  size_t write(uint32_t data) {
+    size_t written = this->udp.write((data >> 24) & 0xff) +
+                      this->udp.write((data >> 16) & 0xff) +
+                      this->udp.write((data >> 8) & 0xff) +
+                      this->udp.write(data & 0xff);
+    totalWritten += written;
+    expected += 4;
+    return written;
+  }
+
+  size_t write(uint64_t data) {
+    size_t written = this->udp.write((data >> 56) & 0xff) +
+                      this->udp.write((data >> 48) & 0xff) +
+                      this->udp.write((data >> 40) & 0xff) +
+                      this->udp.write((data >> 32) & 0xff) +
+                      this->udp.write((data >> 24) & 0xff) +
+                      this->udp.write((data >> 16) & 0xff) +
+                      this->udp.write((data >> 8) & 0xff) +
+                      this->udp.write(data & 0xff);
+    totalWritten += written;
+    expected += 8;
+    return written;
+  }
+};
+
+END_APPLEMIDI_NAMESPACE

--- a/src/utility/PacketWriter.hpp
+++ b/src/utility/PacketWriter.hpp
@@ -6,8 +6,6 @@
 
 #pragma once
 
-#include <stdint.h>
-
 BEGIN_APPLEMIDI_NAMESPACE
 
 template<class UdpClass>

--- a/src/utility/RtpMidi_Clock.h
+++ b/src/utility/RtpMidi_Clock.h
@@ -23,8 +23,8 @@ typedef struct RtpMidi_Clock {
 
 	uint32_t clockRate_;
 
-    unsigned long startTime_;
-    uint32_t timestamp_;
+  unsigned long startTime_;
+  uint32_t timestamp_;
 
 	void Init(uint32_t initialTimeStamp, uint32_t clockRate)
 	{
@@ -35,41 +35,39 @@ typedef struct RtpMidi_Clock {
 			clockRate_ = MIDI_SAMPLING_RATE_DEFAULT;
 		}
 
-        startTime_ = Ticks();
+    startTime_ = Ticks();
 	}
 
-    /// <summary>
-    ///     Returns an timestamp value suitable for inclusion in a RTP packet header.
-    /// </summary>
-    uint32_t Now()
-    {
-        return CalculateCurrentTimeStamp();
-    }
+	/// <summary>
+	///     Returns an timestamp value suitable for inclusion in a RTP packet header.
+	/// </summary>
+	uint32_t Now()
+	{
+		return CalculateCurrentTimeStamp();
+	}
 
 	uint32_t CalculateCurrentTimeStamp()
 	{
 		uint32_t lapse = CalculateTimeSpent();
 
 		// check for potential overflow
-		if (timestamp_ + lapse < UINT_MAX )
+		if (lapse < 0xffffffff - timestamp_)
 			return timestamp_ + lapse;
 
-		uint32_t remainder = UINT_MAX  - timestamp_;
+		uint32_t remainder = 0xffffffff - timestamp_;
 		return lapse - remainder;
 	}
 
 	/// <summary>
-    ///     Returns the time spent since the initial clock timestamp value.
-    ///     The returned value is expressed in units of "clock pulsations",
-    ///     that are equivalent to seconds, scaled by the clock rate.
-    ///     i.e: 1 second difference will result in a delta value equals to the clock rate.
-    /// </summary>
+	///     Returns the time spent since the initial clock timestamp value.
+	///     The returned value is expressed in units of "clock pulsations",
+	///     that are equivalent to seconds, scaled by the clock rate.
+	///     i.e: 1 second difference will result in a delta value equals to the clock rate.
+	/// </summary>
 	uint32_t CalculateTimeSpent()
 	{
-		unsigned long ticks = Ticks() - startTime_;
-		unsigned long seconds = ticks / MSEC_PER_SEC;
-
-		uint32_t lapse = (uint32_t)(seconds * clockRate_);
+		uint32_t ticks = Ticks() - startTime_;
+		uint32_t lapse = (ticks * clockRate_) / MSEC_PER_SEC;
 		return lapse;
 	}
 


### PR DESCRIPTION
This is related to #35 

There have been two main issues addressed:
- Calculation of the timestamp was not properly done and has been fixed. Basically the scaling by the clock rate has been moved before the integer division by ```MSEC_PER_SEC``` to avoid loss of precision.
- The compiler already introduces padding by default for ```AppleMIDI_Syncronization``` but the typedef struct is defining padding explicitly (which at the end is summed to the compiler one). I have added ```__attribute__((packed))``` (specific to gcc) to avoid the compiler to add padding automatically. The way to specify packing is compiler specific, and so device specific, so this change might break compatibility with other devices and it requires some careful review to end having a macro that uses the appropriate solution depending on the compiler.

After looking at the Wireshark data, I suspect that the padding problem might be happening with other structs as well.