### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -22,10 +22,10 @@ noteOff	             KEYWORD2
 afterTouchPoly	     KEYWORD2
 controlChange	     KEYWORD2
 programChange	     KEYWORD2
-afterTouchChannel    KEYWORD2
+afterTouchChannel	KEYWORD2
 pitchBend	         KEYWORD2
 systemExclusive	     KEYWORD2
-timeCodeQuarterFrame KEYWORD2
+timeCodeQuarterFrame	KEYWORD2
 songPosition	     KEYWORD2
 songSelect	         KEYWORD2
 tuneRequest	         KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords