### PR TITLE
fixed pitch bend byte order and offset

### DIFF
--- a/src/utility/packet-rtp-midi.h
+++ b/src/utility/packet-rtp-midi.h
@@ -3,7 +3,7 @@
  *  Project		Arduino AppleMIDI Library
  *	@brief		AppleMIDI Library for the Arduino
  *	Version		0.0
- *  @author		lathoub, hackmancoltaire, rolimat
+ *  @author		lathoub, hackmancoltaire, rolimat, massimofasciano
  *	@date		01/04/13
  *  License		Code is open source so please feel free to do anything you want with it; you buy me a beer if you use this and we meet someday (Beerware license).
  */
@@ -1304,7 +1304,7 @@ DEBUGSTREAM.println("aborted MIDI-command 2: pitch_bend_change");
 			return cmd_len;
 		}
 
-		int pitch = ( octet1 << 7 ) | octet2;
+		int pitch = (( octet2 << 7 ) | octet1) - 8192;
 
 		if ( using_rs ) {
 		} else {


### PR DESCRIPTION
Fixes 2 issues with the decoding of incoming pitch bend events.

In packet-rtp-midi.h, the following line
int pitch = ( octet1 << 7 ) | octet2;
is replaced with
int pitch = (( octet2 << 7 ) | octet1) - 8192;

This should correct both issues:

1) the 2 octets (high and low) were reversed (low appears first in the midi stream)
2) the 8192 negative offset was not applied to get a signed int (midi encodes from 0 to 16383 but we expect -8192 to 8191)
