### PR TITLE
Remove processed rtp-journal data from buffer

### DIFF
--- a/src/rtpMIDI_Parser_JournalSection.hpp
+++ b/src/rtpMIDI_Parser_JournalSection.hpp
@@ -41,6 +41,8 @@ parserReturn decodeJournalSection(RtpBuffer_t &buffer)
 
         if ((flags & RTP_MIDI_JS_FLAG_Y) == 0 && (flags & RTP_MIDI_JS_FLAG_A) == 0)
         {
+            while (minimumLen-- > 0)
+                buffer.pop_front();
             return parserReturn::Processed;
         }
         


### PR DESCRIPTION
When journal section is present but has no entries the data pointer isn't advanced. That causes the next parsing to attempt to analyse the wrong data which of course fail.

This small PR fixes the issue.

It's also possible that `_journalSectionComplete` should be also set:
```C++
 _journalSectionComplete = true;
```
I'm not sure about that, please add if necessary.