### PR TITLE
Example demonstrating how to create dynamic instance instead of macro

### DIFF
--- a/examples/ESP32_DynamicInstantiation/ESP32_dynamicClass.ino
+++ b/examples/ESP32_DynamicInstantiation/ESP32_dynamicClass.ino
@@ -1,0 +1,57 @@
+#include <WiFi.h>
+
+#include "ETH_Helper.h"       
+
+#define SerialMon Serial
+#include "midiHelpers.h"
+
+
+#define ethernet true;        // set to false to demonstrate WiFi usage
+
+char ssid[] = "ssid"; //  your network SSID (name)
+char pass[] = "pass";    // your network password (use for WPA, or use as key for WEP)
+
+MidiClient* midiClient;     // generic class offered as an alternative of the MACRO
+
+void OnAppleMidiException(const APPLEMIDI_NAMESPACE::ssrc_t&, const APPLEMIDI_NAMESPACE::Exception&, const int32_t);   
+
+void WIFI_startup(){
+  WiFi.begin(ssid, pass);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    AM_DBG(F("Establishing connection to WiFi.."));
+  }
+}
+
+void setup(){
+
+  AM_DBG_SETUP(115200);
+
+  bool useEth = false;
+
+  if (useEth){
+    ETH_startup();
+    midiClient = new AppleMidiWithInterfaceWrapper<EthernetUDP>("APPLE_MIDIETHCLIENT",DEFAULT_CONTROL_PORT);
+  }else{
+    WIFI_startup();
+    midiClient = new AppleMidiWithInterfaceWrapper<WiFiUDP>("APPLE_MIDIWIFICLIENT",DEFAULT_CONTROL_PORT);             
+  }
+
+  midiClient->begin();
+
+  midiClient->setHandleConnected([](const APPLEMIDI_NAMESPACE::ssrc_t & ssrc, const char* name) {
+    AM_DBG(F("Connected to session"), ssrc, name);
+  });
+  midiClient->setHandleDisconnected([](const APPLEMIDI_NAMESPACE::ssrc_t & ssrc) {
+    AM_DBG(F("Disconnected"), ssrc);
+  });
+
+  AM_DBG(F("OK, now make sure you have an rtpMIDI session that is Enabled"));
+  AM_DBG(F("Add device named Arduino with Host"), useEth?Ethernet.localIP():WiFi.localIP(), "Port", midiClient->getPort(), "(Name", midiClient->getName(), ")");
+  AM_DBG(F("Select and then press the Connect button"));
+  AM_DBG(F("Then open a MIDI listener and monitor incoming notes")); 
+}
+
+void loop(){
+  midiClient->read();
+}

--- a/examples/ESP32_DynamicInstantiation/ETH_helper.h
+++ b/examples/ESP32_DynamicInstantiation/ETH_helper.h
@@ -1,0 +1,110 @@
+#ifdef ETHERNET3
+#include <Ethernet3.h>
+#else
+#include <Ethernet.h>
+#include <EthernetBonjour.h> // https://github.com/TrippyLighting/EthernetBonjour
+#endif
+
+// to get the Mac address
+#include <WiFi.h>
+
+#define RESET_PIN  D7
+#define CS_PIN     D5
+
+// Enter a MAC address for your controller below.
+// Newer Ethernet shields have a MAC address printed on a sticker on the shield
+byte mac[] = {
+  0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED
+};
+
+/*
+   Wiz W5500 reset function.  Change this for the specific reset
+   sequence required for your particular board or module.
+*/
+void hardreset() {
+  pinMode(RESET_PIN, OUTPUT);
+  digitalWrite(RESET_PIN, HIGH);
+  delay(150);
+
+  digitalWrite(RESET_PIN, LOW);
+  delay(500);
+  digitalWrite(RESET_PIN, HIGH);
+  delay(150);
+}
+
+bool ETH_startup()
+{
+#ifdef ETHERNET3
+  Ethernet.setRstPin(RESET_PIN);
+  Ethernet.setCsPin(CS_PIN);
+  Ethernet.init(4); // maxSockNum = 4 Socket 0...3 -> RX/TX Buffer 4k
+  Serial.println("Resetting Wiz W5500 Ethernet Board...  ");
+  Ethernet.hardreset();
+#else
+  Ethernet.init(CS_PIN);
+  Serial.println("Resetting Wiz Ethernet Board...  ");
+  hardreset();
+#endif
+
+  esp_read_mac(mac, ESP_MAC_WIFI_STA);
+
+  /*
+      Network configuration - all except the MAC are optional.
+
+      IMPORTANT NOTE - The mass-produced W5500 boards do -not-
+                       have a built-in MAC address (depite
+                       comments to the contrary elsewhere). You
+                       -must- supply a MAC address here.
+  */
+#ifdef ETHERNET3
+  Serial.println("Starting Ethernet3 connection...");
+#else
+  Serial.println("Starting Ethernet connection...");
+  //if (Ethernet.hardwareStatus() == EthernetNoHardware) Serial.println("No EthernetHW");  
+#endif
+  Ethernet.begin(mac);
+  Serial.print("Ethernet IP is: ");
+  Serial.println(Ethernet.localIP());
+
+  /*
+     Sanity checks for W5500 and cable connection.
+  */
+  Serial.println("Checking connection.");
+  bool rdy_flag = false;
+  for (uint8_t i = 0; i <= 20; i++) {
+#ifdef ETHERNET3
+    if ((Ethernet.link() == 0)) {
+#else
+    if ((Ethernet.linkStatus() == Unknown)) {
+#endif
+      Serial.print(".");
+      rdy_flag = false;
+      delay(80);
+    } else {
+      rdy_flag = true;
+      break;
+    }
+  }
+  if (rdy_flag == false) {
+    Serial.println("\n\r\tHardware fault, or cable problem... cannot continue.");
+    while (true) {
+      delay(10);          // Halt.
+    }
+  } else {
+    Serial.println("OK");
+  }
+
+#ifndef ETHERNET3
+  // Initialize the Bonjour/MDNS library. You can now reach or ping this
+  // Arduino via the host name "arduino.local", provided that your operating
+  // system is Bonjour-enabled (such as MacOS X).
+  // Always call this before any other method!
+  EthernetBonjour.begin("arduino");
+
+  EthernetBonjour.addServiceRecord("apple-midi",        //Arduino._apple-midi doesnt work
+                                   5004,
+                                   MDNSServiceUDP);
+#endif
+
+  return true;
+}

--- a/examples/ESP32_DynamicInstantiation/midiHelpers.h
+++ b/examples/ESP32_DynamicInstantiation/midiHelpers.h
@@ -1,0 +1,87 @@
+#ifndef MIDIHELPERS_h
+#define MIDIHELPERS_h
+
+#define USE_EXT_CALLBACKS     // as from example => required for MIDI callbacks
+#include <AppleMIDI.h>         //https://github.com/lathoub/Arduino-AppleMIDI-Library
+
+using namespace APPLEMIDI_NAMESPACE;
+
+/*
+class Utilities for creating a generic pointer to AppleMIDISession and MidiInterface
+from a WiFiUDP or EThernetUDP (template) and be able to manipulate it as a generic instance
+and manipulating the pointer generically
+*/
+
+class MidiClient {
+public:
+  virtual void read() = 0;
+  virtual ~MidiClient() {}
+  virtual void setHandleConnected(void (*fptr)(const ssrc_t &, const char *))= 0;
+  virtual void setHandleDisconnected(void (*fptr)(const ssrc_t &)) = 0;
+  virtual void setHandleException(void (*fptr)(const ssrc_t &, const Exception &, const int32_t value))=0;
+  virtual const char *getName() = 0;
+  virtual const uint16_t getPort() = 0;
+  virtual void begin() = 0;
+  // all methods you need to be wrapped below
+  virtual void sendNoteOn(byte note, byte velocity, byte channel) = 0;
+  virtual void sendNoteOff(byte note, byte velocity, byte channel) = 0;  
+  // etc...
+
+};
+
+template <typename UdpType>
+class AppleMidiWithInterfaceWrapper : public MidiClient {
+public:
+  AppleMIDISession<UdpType>* session;
+  MidiInterface<AppleMIDISession<UdpType>, AppleMIDISettings>* midi;
+
+  AppleMidiWithInterfaceWrapper<UdpType>(const char* sessionName, uint16_t port) {
+    session = new AppleMIDISession<UdpType>(sessionName, port);
+    midi = new MidiInterface<AppleMIDISession<UdpType>, AppleMIDISettings>(*session);   
+  }
+
+  virtual void begin(){
+    session->begin();    
+  }
+
+  virtual const char *getName(){
+    return session->getName();
+  }
+
+  virtual const uint16_t getPort(){
+    return session->getPort();
+  }
+
+  virtual void setHandleConnected(void (*fptr)(const ssrc_t &, const char *)){
+    session->setHandleConnected(fptr);
+  }
+
+  virtual void setHandleDisconnected(void (*fptr)(const ssrc_t &)){
+    session->setHandleDisconnected(fptr);
+  }
+
+  virtual void setHandleException(void (*fptr)(const ssrc_t &, const Exception &, const int32_t value)){
+    session->setHandleException(fptr);
+  }
+
+
+  void read() override {
+    midi->read();
+  }
+
+  void sendNoteOn(byte note, byte velocity, byte channel) override {
+    midi->sendNoteOn(note, velocity, channel);
+  }
+
+  void sendNoteOff(byte note, byte velocity, byte channel) override {
+    midi->sendNoteOff(note, velocity, channel);
+  }
+
+
+  ~AppleMidiWithInterfaceWrapper() {
+    delete midi;
+    delete session;
+  }
+};
+
+#endif


### PR DESCRIPTION
This implements an example for https://github.com/FortySevenEffects/arduino_midi_library/discussions/366

implements a class Utilities for creating a generic pointer to AppleMIDISession and MidiInterface from a WiFiUDP or EThernetUDP (template) and be able to manipulate it as a generic instance and manipulating the pointer generically

Provide an example on how to use it