### PR TITLE
Fix: Validate initiator token in EndSession to prevent stale session disconnects

### DIFF
--- a/src/AppleMIDI.hpp
+++ b/src/AppleMIDI.hpp
@@ -468,7 +468,8 @@ void AppleMIDISession<UdpClass, Settings, Platform>::ReceivedEndSession(AppleMID
 #else
     {
 #endif
-        if (endSession.ssrc == participant.ssrc)
+        if (endSession.ssrc == participant.ssrc &&
+                endSession.initiatorToken == participant.initiatorToken)
         {
             auto ssrc = participant.ssrc;
 


### PR DESCRIPTION
The library was only checking SSRC when processing EndSession (disconnect) messages, but the RTP MIDI protocol requires validation of BOTH the SSRC and initiator token.

This bug causes stale disconnect messages (from previous sessions that reused the same SSRC) to incorrectly tear down active connections after device reconnections.

Fixes reconnection issues where macOS reuses SSRCs for new sessions before old sessions timeout, leading to spurious disconnects ~60 seconds after reconnection.

Tested on Wiznet W5500-EVB-Pico2 with custom firmware, but applies fairly globally.