### PR TITLE
Quash compile warnings

### DIFF
--- a/src/rtpMIDI_Parser_JournalSection.hpp
+++ b/src/rtpMIDI_Parser_JournalSection.hpp
@@ -137,9 +137,9 @@ parserReturn decodeJournalSection(RtpBuffer_t &buffer)
             cb.buffer[3] = buffer[2];
             uint32_t chanflags = __ntohl(cb.value32);
 
-            bool S_flag         = (chanflags & RTP_MIDI_CJ_FLAG_S) == 1;
-            uint8_t channelNr   = (chanflags & RTP_MIDI_CJ_MASK_CHANNEL) >> RTP_MIDI_CJ_CHANNEL_SHIFT; 
-            bool H_flag         = (chanflags & RTP_MIDI_CJ_FLAG_H) == 1;
+            //bool S_flag         = (chanflags & RTP_MIDI_CJ_FLAG_S) == 1;
+            //uint8_t channelNr   = (chanflags & RTP_MIDI_CJ_MASK_CHANNEL) >> RTP_MIDI_CJ_CHANNEL_SHIFT; 
+            //bool H_flag         = (chanflags & RTP_MIDI_CJ_FLAG_H) == 1;
             uint8_t chanjourlen = (chanflags & RTP_MIDI_CJ_MASK_LENGTH) >> 8;
 
             if ((chanflags & RTP_MIDI_CJ_FLAG_P)) {

--- a/src/utility/Deque.h
+++ b/src/utility/Deque.h
@@ -11,7 +11,7 @@ class Deque {
 
 private:
     // _tail can briefly go to -1 during wraparound in push_front
-    // _head same behavior in pop_back
+    // _head has same behavior in pop_back
     int _head, _tail;
     T _data[Size];
     

--- a/src/utility/Deque.h
+++ b/src/utility/Deque.h
@@ -4,11 +4,14 @@
 
 BEGIN_APPLEMIDI_NAMESPACE
 
+
 template<typename T, size_t Size>
 class Deque {
 //    class iterator;
 
 private:
+    // _tail can briefly go to -1 during wraparound in push_front
+    // _head same behavior in pop_back
     int _head, _tail;
     T _data[Size];
     
@@ -123,7 +126,9 @@ void Deque<T, Size>::push_back(const T &value)
         _data[_head] = value;
         if (empty())
             _tail = _head;
-        if (++_head >= Size)
+
+        // cast is safe because _head cannot here be negative
+        if ((size_t)(++_head) >= Size)
             _head %= Size;
     }
 }
@@ -190,7 +195,8 @@ template<typename T, size_t Size>
 void Deque<T, Size>::pop_front() {
     if (empty()) // if empty, do nothing.
         return;
-    if (++_tail >= Size)
+    // cast is safe because _tail cannot here be negative
+    if ((size_t)(++_tail) >= Size)
         _tail %= Size;
     if (_tail == _head)
         clear();


### PR DESCRIPTION
Hi, this PR takes care of a few compile warnings that appear when compiling for Arduino Due in PlatformIO on an M5 Mac (i.e. native Apple silicon):

- 3 unused vars in rtpMIDI_Parser_JournalSection.hpp.
- 2 signed/unsigned comparison warnings in Deque.h.  I analyzed the size_t casts I added and think they are safe.

I did not bump the version - leaving that to your policy.

Best regards (and thanks for making these libraries!),
Dave Cook